### PR TITLE
Fix for drive array growing each time getDrives is called

### DIFF
--- a/lib/diskinfo.js
+++ b/lib/diskinfo.js
@@ -9,7 +9,6 @@
 
 var exec = require('child_process').exec;
 var os = require('os');
-var aDrives = [];
 
 /**
 *	Returns an array of drives or calls callback 
@@ -18,6 +17,7 @@ var aDrives = [];
 *						the array of drives, set null if no callback 
 */
 exports.getDrives = function(callback) {
+	var aDrives = [];
 	
 	switch (os.platform().toLowerCase()) {
         case 'win32':

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "os": [
     "linux",
-    "win32"
+    "win32",
+    "darwin"
   ],
   "devDependencies": {    
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Benoit Gauthier",
   "name": "diskinfo",
   "description": "Nodejs module to get drive information, tested on linux centos and windows vista",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "main": "./lib/diskinfo.js",
   "scripts": {   


### PR DESCRIPTION
Move array variable inside function so it does not grow with each call to getDrives.

Also add darwin to os list in package.json, module works correctly for darwin (OSX).